### PR TITLE
Support subclasses of `Illuminate\Database\Schema\*Connection`

### DIFF
--- a/src/Service/Dumper.php
+++ b/src/Service/Dumper.php
@@ -37,10 +37,10 @@ class Dumper
 
     protected function schemaState(Connection $connection): ?SchemaState
     {
-        return match (get_class($connection)) {
-            SQLiteConnection::class   => new SQLiteSchemaState($connection, null, null),
-            MySqlConnection::class    => new MySqlSchemaState($connection, null, null),
-            PostgresConnection::class => new PostgresSchemaState($connection, null, null),
+        return match (true) {
+            $connection instanceof SQLiteConnection   => new SQLiteSchemaState($connection, null, null),
+            $connection instanceof MySqlConnection   => new MySqlSchemaState($connection, null, null),
+            $connection instanceof PostgresConnection => new PostgresSchemaState($connection, null, null),
             default                   => null
         };
     }


### PR DESCRIPTION
This change allows a very popular package ([staudenmeir/eloquent-has-many-deep](staudenmeir/eloquent-has-many-deep)) to work together with **laravel-data-dumper**.

Without this, `schemaState(Connection $connection)` always returns null, because the connection class is `Staudenmeir\LaravelCte\Connections\MySqlConnection` instead of the expected one.

